### PR TITLE
Fix Unknown Case Warning

### DIFF
--- a/Plugins/VersionFile/VersionFile.swift
+++ b/Plugins/VersionFile/VersionFile.swift
@@ -190,14 +190,14 @@ private extension VersionFile {
         process.waitUntilExit()
 
         // Check whether the subprocess invocation was successful.
-        if process.terminationReason == .exit && process.terminationStatus == 0 {
-            return String(
-                decoding: outputPipe.fileHandleForReading.readDataToEndOfFile(),
-                as: UTF8.self)
-        } else {
+        guard process.terminationReason == .exit && process.terminationStatus == 0 else {
             let problem = "\(process.terminationReason):\(process.terminationStatus)"
             Diagnostics.error("\(tool) invocation failed: \(problem)")
             throw problem
         }
+
+        return String(
+            decoding: outputPipe.fileHandleForReading.readDataToEndOfFile(),
+            as: UTF8.self)
     }
 }

--- a/Plugins/VersionFile/VersionFile.swift
+++ b/Plugins/VersionFile/VersionFile.swift
@@ -124,6 +124,9 @@ private extension VersionFile {
                 return target
             case .test:
                 return nil
+            @unknown default:
+                Diagnostics.warning("Unrecognized product type for target \(target.name): \(target.kind)")
+                return nil
             }
         }
     }


### PR DESCRIPTION
Building with Swift 5.9 produces the following warning:

```
Switch covers known cases, but 'ModuleKind' may have additional unknown values
```

This fixes that by handling unknown `SourceModuleTarget.kind` cases.

I also updated the `run(tool:with:)` method to handle invocation failures with `guard`.